### PR TITLE
Deprecated: tf.math.unsorted_segment_max

### DIFF
--- a/waymo_open_dataset/utils/range_image_utils.py
+++ b/waymo_open_dataset/utils/range_image_utils.py
@@ -223,7 +223,7 @@ def build_camera_depth_image(range_image_cartesian,
                              camera_projection,
                              camera_image_size,
                              camera_name,
-                             pool_method=tf.unsorted_segment_min,
+                             pool_method=tf.math.unsorted_segment_min,
                              scope=None):
   """Builds camera depth image given camera projections.
 
@@ -413,7 +413,7 @@ def build_range_image_from_point_cloud(points_vehicle_frame,
         ri_index = ri_index[0:num_point, :]
         ri_value = ri_value[0:num_point]
         range_image = _scatter_nd_with_pool(ri_index, ri_value, [height, width],
-                                            tf.unsorted_segment_max)
+                                            tf.math.unsorted_segment_max)
         return range_image
 
       range_images = tf.map_fn(


### PR DESCRIPTION
Using Tensorflow version 2.0, the call `tf.unsorted_segment_max` threw an error, since `tf.unsorted_segment_max` was deprecated after Tensorflow version 1.14 and the warning in v1.14 suggests using `tf.math.unsorted_segment_max` instead. This is the same for `tf.math.unsorted_segment_min`.

> WARNING:tensorflow:From /usr/local/lib/python3.5/site-packages/waymo_open_dataset/utils/range_image_utils.py:59: The name tf.unsorted_segment_max is deprecated. Please use tf.math.unsorted_segment_max instead.