### PR TITLE
construct camera_image_metadata tensor explicitly

### DIFF
--- a/third_party/camera/ops/camera_model_ops_test.py
+++ b/third_party/camera/ops/camera_model_ops_test.py
@@ -140,6 +140,7 @@ class CameraModelOpsTest(tf.test.TestCase):
       camera_image_metadata.append(image.shutter)
       camera_image_metadata.append(image.camera_trigger_time)
       camera_image_metadata.append(image.camera_readout_done_time)
+      camera_image_metadata = tf.constant(camera_image_metadata, dtype=tf.float32)
       image_points = tf.constant([[100, 1000, 20], [150, 1000, 20]],
                                  dtype=tf.float32)
 


### PR DESCRIPTION
@peisun1115
It seems that tf.tensor support converting from list implicitly.