### PR TITLE
fix Dockerfile - change the bazel version to 0.28.0

### DIFF
--- a/tutorial/cpu-jupyter.Dockerfile
+++ b/tutorial/cpu-jupyter.Dockerfile
@@ -4,9 +4,10 @@ RUN apt-get update && apt-get install -y \
   git build-essential wget vim findutils curl \
   pkg-config zip g++ zlib1g-dev unzip python3 python3-pip
 
-RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
-    curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
-    apt-get update && apt-get install -y bazel
+RUN apt-get install -y wget
+RUN wget https://github.com/bazelbuild/bazel/releases/download/0.28.0/bazel-0.28.0-installer-linux-x86_64.sh 
+RUN chmod +x bazel-0.28.0-installer-linux-x86_64.sh
+RUN bash ./bazel-0.28.0-installer-linux-x86_64.sh 
 
 RUN pip3 install jupyter matplotlib jupyter_http_over_ws &&\
   jupyter serverextension enable --py jupyter_http_over_ws


### PR DESCRIPTION
In the latest master the Docker build crashes. The issue is related to Bazel configuration / version. After running 
`docker build --tag=open_dataset -f tutorial/cpu-jupyter.Dockerfile ` as described [here](https://github.com/waymo-research/waymo-open-dataset/blob/master/tutorial/tutorial_local.ipynb), the following error message is thrown in the log output:

```
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Options provided by the client:
  Inherited 'common' options: --isatty=0 --terminal_columns=80
INFO: Reading rc options for 'query' from /waymo-od/.bazelrc:
  'query' options: --incompatible_bzl_disallow_load_after_statement=false
ERROR: Unrecognized option: --incompatible_bzl_disallow_load_after_statement=false
INFO: Options provided by the client:
  Inherited 'common' options: --isatty=0 --terminal_columns=80
INFO: Reading rc options for 'build' from /waymo-od/.bazelrc:
  'build' options: -c opt --cxxopt=-std=c++11 --auto_output_filter=subpackages --copt=-Wall --copt=-Wno-sign-compare --linkopt=-lrt -lm --incompatible_bzl_disallow_load_after_statement=false --action_env TF_HEADER_DIR=/usr/local/lib/python3.6/dist-packages/tensorflow_core/include --action_env TF_SHARED_LIBRARY_DIR=/usr/local/lib/python3.6/dist-packages/tensorflow_core --action_env TF_SHARED_LIBRARY_NAME=libtensorflow_framework.so.2 --action_env TF_NEED_CUDA=0 --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0
ERROR: Unrecognized option: --incompatible_bzl_disallow_load_after_statement=false

```

One quick fix is to just use the Bazel version 0.28.0 that is explicitly used in this [colab tutorial version](https://colab.research.google.com/github/waymo-research/waymo-open-dataset/blob/master/tutorial/tutorial.ipynb#scrollTo=923OIUNSFCFw).
