### PR TITLE
use 64-bit floats for camera model tensorflow ops

### DIFF
--- a/third_party/camera/ops/camera_model_ops.cc
+++ b/third_party/camera/ops/camera_model_ops.cc
@@ -69,12 +69,12 @@ void ParseInput(const Input& input, co::CameraCalibration* calibration_ptr,
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
       calibration.mutable_extrinsic()->add_transform(
-          input.extrinsic->matrix<float>()(i, j));
+          input.extrinsic->matrix<double>()(i, j));
     }
   }
   CHECK_EQ(input.intrinsic->dim_size(0), kIntrinsicLen);
   for (int i = 0; i < kIntrinsicLen; ++i) {
-    calibration.add_intrinsic(input.intrinsic->vec<float>()(i));
+    calibration.add_intrinsic(input.intrinsic->vec<double>()(i));
   }
   CHECK_EQ(input.metadata->dim_size(0), kMetadataLen);
   calibration.set_width(input.metadata->vec<int32>()(0));
@@ -84,7 +84,7 @@ void ParseInput(const Input& input, co::CameraCalibration* calibration_ptr,
           input.metadata->vec<int32>()(2)));
   CHECK_EQ(input.camera_image_metadata->dim_size(0), kCameraImageMedataLen);
   int idx = 0;
-  const auto& cim = input.camera_image_metadata->vec<float>();
+  const auto& cim = input.camera_image_metadata->vec<double>();
   for (; idx < 16; ++idx) {
     image.mutable_pose()->add_transform(cim(idx));
   }
@@ -123,18 +123,18 @@ class WorldToImageOp final : public OpKernel {
 
     const int num_points = input.input_coordinate->dim_size(0);
     CHECK_EQ(3, input.input_coordinate->dim_size(1));
-    Tensor image_coordinates(DT_FLOAT, {num_points, 3});
+    Tensor image_coordinates(DT_DOUBLE, {num_points, 3});
     for (int i = 0; i < num_points; ++i) {
       double u_d = 0.0;
       double v_d = 0.0;
       const bool valid =
-          model.WorldToImage(input.input_coordinate->matrix<float>()(i, 0),
-                             input.input_coordinate->matrix<float>()(i, 1),
-                             input.input_coordinate->matrix<float>()(i, 2),
+          model.WorldToImage(input.input_coordinate->matrix<double>()(i, 0),
+                             input.input_coordinate->matrix<double>()(i, 1),
+                             input.input_coordinate->matrix<double>()(i, 2),
                              /*check_image_bounds=*/false, &u_d, &v_d);
-      image_coordinates.matrix<float>()(i, 0) = u_d;
-      image_coordinates.matrix<float>()(i, 1) = v_d;
-      image_coordinates.matrix<float>()(i, 2) = static_cast<float>(valid);
+      image_coordinates.matrix<double>()(i, 0) = u_d;
+      image_coordinates.matrix<double>()(i, 1) = v_d;
+      image_coordinates.matrix<double>()(i, 2) = static_cast<double>(valid);
     }
     ctx->set_output(0, image_coordinates);
   }
@@ -165,18 +165,18 @@ class ImageToWorldOp final : public OpKernel {
 
     const int num_points = input.input_coordinate->dim_size(0);
     CHECK_EQ(3, input.input_coordinate->dim_size(1));
-    Tensor global_coordinates(DT_FLOAT, {num_points, 3});
+    Tensor global_coordinates(DT_DOUBLE, {num_points, 3});
     for (int i = 0; i < num_points; ++i) {
       double x = 0.0;
       double y = 0.0;
       double z = 0.0;
-      model.ImageToWorld(input.input_coordinate->matrix<float>()(i, 0),
-                         input.input_coordinate->matrix<float>()(i, 1),
-                         input.input_coordinate->matrix<float>()(i, 2), &x, &y,
+      model.ImageToWorld(input.input_coordinate->matrix<double>()(i, 0),
+                         input.input_coordinate->matrix<double>()(i, 1),
+                         input.input_coordinate->matrix<double>()(i, 2), &x, &y,
                          &z);
-      global_coordinates.matrix<float>()(i, 0) = x;
-      global_coordinates.matrix<float>()(i, 1) = y;
-      global_coordinates.matrix<float>()(i, 2) = z;
+      global_coordinates.matrix<double>()(i, 0) = x;
+      global_coordinates.matrix<double>()(i, 1) = y;
+      global_coordinates.matrix<double>()(i, 2) = z;
     }
     ctx->set_output(0, global_coordinates);
   }
@@ -186,12 +186,12 @@ REGISTER_KERNEL_BUILDER(Name("ImageToWorld").Device(DEVICE_CPU),
                         ImageToWorldOp);
 
 REGISTER_OP("WorldToImage")
-    .Input("extrinsic: float")
-    .Input("intrinsic: float")
+    .Input("extrinsic: double")
+    .Input("intrinsic: double")
     .Input("metadata: int32")
-    .Input("camera_image_metadata: float")
-    .Input("global_coordinate: float")
-    .Output("image_coordinate: float")
+    .Input("camera_image_metadata: double")
+    .Input("global_coordinate: double")
+    .Output("image_coordinate: double")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       return Status::OK();
     })
@@ -205,8 +205,8 @@ metadata: [3] CameraCalibration::[width, height, rolling_shutter_direction].
 camera_image_metadata: [16 + 6 + 1 + 1 + 1 + 1]=[26] tensor.
   CameraImage::[pose(16), velocity(6), pose_timestamp(1), shutter(1),
   camera_trigger_time(1), camera_readout_done_time(1)].
-global_coordinate: [N, 3] float tensor. Points in global frame.
-image_coordinate: [N, 3] float tensor. [N, 0:2] are points in image frame.
+global_coordinate: [N, 3] float64 tensor. Points in global frame.
+image_coordinate: [N, 3] float64 tensor. [N, 0:2] are points in image frame.
   The points can be outside of the image. The last channel [N, 2] tells whether
   a projection is valid or not. 0 means invalid. 1 means valid. A projection
   can be invalid if the point is behind the camera or if the radial distortion
@@ -214,12 +214,12 @@ image_coordinate: [N, 3] float tensor. [N, 0:2] are points in image frame.
 )doc");
 
 REGISTER_OP("ImageToWorld")
-    .Input("extrinsic: float")
-    .Input("intrinsic: float")
+    .Input("extrinsic: double")
+    .Input("intrinsic: double")
     .Input("metadata: int32")
-    .Input("camera_image_metadata: float")
-    .Input("image_coordinate: float")
-    .Output("global_coordinate: float")
+    .Input("camera_image_metadata: double")
+    .Input("image_coordinate: double")
+    .Output("global_coordinate: double")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       return Status::OK();
     })
@@ -233,8 +233,8 @@ metadata: [3] CameraCalibration::[width, height, rolling_shutter_direction].
 camera_image_metadata: [16 + 6 + 1 + 1 + 1 + 1]=[26] tensor.
   CameraImage::[pose(16), velocity(6), pose_timestamp(1), shutter(1),
   camera_trigger_time(1), camera_readout_done_time(1)].
-image_coordinate: [N, 3] float tensor. Points in image frame with depth.
-global_coordinate: [N, 3] float tensor. Points in global frame.
+image_coordinate: [N, 3] float64 tensor. Points in image frame with depth.
+global_coordinate: [N, 3] float64 tensor. Points in global frame.
 )doc");
 
 }  // namespace

--- a/third_party/camera/ops/camera_model_ops_test.py
+++ b/third_party/camera/ops/camera_model_ops_test.py
@@ -121,9 +121,9 @@ class CameraModelOpsTest(tf.test.TestCase):
     g = tf.Graph()
     with g.as_default():
       extrinsic = tf.reshape(
-          tf.constant(list(calibration.extrinsic.transform), dtype=tf.float32),
+          tf.constant(list(calibration.extrinsic.transform), dtype=tf.float64),
           [4, 4])
-      intrinsic = tf.constant(list(calibration.intrinsic), dtype=tf.float32)
+      intrinsic = tf.constant(list(calibration.intrinsic), dtype=tf.float64)
       metadata = tf.constant([
           calibration.width, calibration.height,
           calibration.rolling_shutter_direction
@@ -141,7 +141,7 @@ class CameraModelOpsTest(tf.test.TestCase):
       camera_image_metadata.append(image.camera_trigger_time)
       camera_image_metadata.append(image.camera_readout_done_time)
       image_points = tf.constant([[100, 1000, 20], [150, 1000, 20]],
-                                 dtype=tf.float32)
+                                 dtype=tf.float64)
 
       global_points = py_camera_model_ops.image_to_world(
           extrinsic, intrinsic, metadata, camera_image_metadata, image_points)


### PR DESCRIPTION
The C++ camera model code in `third_party/camera/camera_model.cc` uses `double`, but the tensorflow op interface in `third_party/camera/ops` was using `float` tensors, leading to precision loss and #146. This PR modifies the tensorflow op to use `double`, for the large part fixing #146.