### PR TITLE
Update setup.py.in with missing comma before immutabledict.

### DIFF
--- a/pip_pkg_scripts/setup.py.in
+++ b/pip_pkg_scripts/setup.py.in
@@ -23,7 +23,7 @@ REQUIRED_PACKAGES = [
     'tensorflow==' + '.'.join('TF_VERSION'.split('-')),
     'plotly>=5.5.0',
     'matplotlib>=3.2.2',
-    'scikit-image>=0.17.2'
+    'scikit-image>=0.17.2',
     'immutabledict>=2.0.0'
 ]
 project_name = 'waymo-open-dataset-tf-TF_VERSION'


### PR DESCRIPTION
When trying to export a conda environment, I was getting the error: `InvalidVersionSpec: Invalid version '0.17.2immutabledict>=2.0.0': invalid character(s)`. Digging deeper, it appears that this bug is causing `python3.7/site-packages/waymo_open_dataset_tf_2_6_0-1.4.9.dist-info/METADATA` to say: `Requires-Dist: scikit-image (>=0.17.2immutabledict>=2.0.0)` instead of `Requires-Dist: scikit-image (>=0.17.2)\nRequires-Dist: immutabledict (>=2.0.0)`.