### PR TITLE
Installing latest Waymo API (#534)

### DIFF
--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -70,7 +70,7 @@
         "colab": {}
       },
       "source": [
-        "!pip3 install waymo-open-dataset-tf-2-1-0==1.2.0"
+        "!pip3 install waymo-open-dataset-tf-2-6-0==1.4.9"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
**Resolves Issue #534 by updating the imported Waymo Open Dataset API to `waymo-open-dataset-tf-2-6-0==1.4.9`.**

Previously imported version references an outdated version of `frame_utils.py`. 

**More info**
The `tutorial.ipynb` notebook relies on the latest `parse_range_image_and_camera_projection()` method call returning a tuple with four values (now with the `segmentation_labels`). This extends the previous method call from commits predating commit [eccb0d4](https://github.com/waymo-research/waymo-open-dataset/commit/eccb0d49f0e272f1c21bb42777e2353ea03f0be0) returning only three tuple values `(range_images, camera_projections, range_image_top_pose)`.