### PR TITLE
Fix get_upright_3d_box_corners to counter-clockwise

### DIFF
--- a/src/waymo_open_dataset/utils/box_utils.py
+++ b/src/waymo_open_dataset/utils/box_utils.py
@@ -163,8 +163,8 @@ def get_upright_3d_box_corners(boxes, name=None):
     # [N, 8, 3]
     corners = tf.reshape(
         tf.stack([
-            l2, w2, -h2, -l2, w2, -h2, -l2, -w2, -h2, l2, -w2, -h2, l2, w2, h2,
-            -l2, w2, h2, -l2, -w2, h2, l2, -w2, h2
+            l2, w2, -h2, l2, -w2, -h2, -l2, -w2, -h2, -l2, w2, -h2, l2, w2, h2,
+            l2, -w2, h2, -l2, -w2, h2, -l2, w2, h2
         ],
                  axis=-1), [-1, 8, 3])
     # [N, 8, 3]


### PR DESCRIPTION
If the heading is counter-clockwise from [-pi, pi], then the original implementation of 3D corners are clockwise.

Fix it to counter-clockwise as expected