### PR TITLE
Fix predict segmentation labels shape

### DIFF
--- a/src/waymo_open_dataset/metrics/tools/create_segmentation_prediction_file_example.py
+++ b/src/waymo_open_dataset/metrics/tools/create_segmentation_prediction_file_example.py
@@ -37,18 +37,22 @@ def _create_single_frame_seg_pd_file_example():
       pd = open_dataset.MatrixInt32()
       for _ in range(50):
         for _ in range(1000):
+          pd.data.append(segmentation_pb2.Segmentation.TYPE_UNDEFINED)
           pd.data.append(segmentation_pb2.Segmentation.TYPE_CAR)
       pd.shape.dims.append(50)
       pd.shape.dims.append(1000)
+      pd.shape.dims.append(2)
       pd_str = zlib.compress(pd.SerializeToString())
       segmentation_label.ri_return1.segmentation_label_compressed = pd_str
       # Add prediction for the second return image.
       pd = open_dataset.MatrixInt32()
       for _ in range(50):
         for _ in range(1000):
+          pd.data.append(segmentation_pb2.Segmentation.TYPE_UNDEFINED)
           pd.data.append(segmentation_pb2.Segmentation.TYPE_PEDESTRIAN)
       pd.shape.dims.append(50)
       pd.shape.dims.append(1000)
+      pd.shape.dims.append(2)
       pd_str = zlib.compress(pd.SerializeToString())
       segmentation_label.ri_return2.segmentation_label_compressed = pd_str
       frame.segmentation_labels.append(segmentation_label)


### PR DESCRIPTION
Hi, Waymo team. I noticed that the create_segmentation_prediction_file_example.py contains a bug in the dummy predicted segmentation labels shape. For each pixel of the range image, the prediction should contain two elements, a dummy one, and a predicted label (aligned with tutorial_3d_semseg).