### PR TITLE
docs(pip_pkg_scripts/README.md): fix docker build instructions

### DIFF
--- a/src/waymo_open_dataset/pip_pkg_scripts/README.md
+++ b/src/waymo_open_dataset/pip_pkg_scripts/README.md
@@ -5,9 +5,9 @@ mkdir /tmp/wod
 cd src
 docker build \
     --tag=open_dataset_pip\
-    -f waymo_open_dataset/waymo_open_dataset/pip_pkg_scripts/build.Dockerfile\
+    -f waymo_open_dataset/pip_pkg_scripts/build.Dockerfile\
     --build-arg USERNAME=$USER\
-    --build-arg USER_UID=$`(id -u `$USER) .
+    --build-arg USER_UID=$(id -u $USER) .
 docker run --mount type=bind,source=/tmp/wod,target=/tmp/wod open_dataset_pip
 ```
 


### PR DESCRIPTION
This fixes the docker build instructions within:

https://github.com/waymo-research/waymo-open-dataset/blob/d16af5cf112a2498d659f87e614ad19f20ca2f56/src/waymo_open_dataset/pip_pkg_scripts/README.md?plain=1#L6-L10

- Removed the typo quotes.
- Fixed the relative directory so the steps are consistent.

Tested by following through and was able to build the `.whl` successfully.